### PR TITLE
Fix: windows python 3.13 install and small deps fixes

### DIFF
--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-
 import struct
 import logging
 from chirp import chirp_common, directory, bitwise, memmap, errors, util

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wxPython>=4.0,<4.2.0 ; platform_system=="Linux" # See https://github.com/wxWidgets/Phoenix/issues/2225
-wxPython==4.2.0 ; platform_system!="Linux"
+wxPython>=4.2.0 ; platform_system!="Linux"
 pyserial
 requests
 pywin32; platform_system=="Windows"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,10 @@
+-r ./requirements.txt
+
 # https://github.com/pytest-dev/pytest/issues/10428
 pytest==7.1.3
 pytest-xdist
 pytest-html
+ddt
+pyyaml
 six
 pep8
-pyserial
-requests
-pyyaml
-pywin32; platform_system=="Windows"
-ddt


### PR DESCRIPTION
This contains minor changes to the requirements file to fix the install under windows for newer python versions.

it also makes the test requirements depend on the normal ones, so that the package is tested against the same requirements as the installation requests them.

Also removes last usage of __future__
